### PR TITLE
Use actions-toolkit for arg parsing

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,6 +1,9 @@
 const IssueCreator = require('.')
+const Toolkit = require('actions-toolkit')
 
-const issueCreator = new IssueCreator(process.argv[2])
-issueCreator.go().then(issue => {
-  console.log(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
-})
+const tools = new Toolkit()
+const issueCreator = new IssueCreator(tools)
+issueCreator.go()
+  .then(issue => {
+    console.log(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+  })

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
-const { Toolkit } = require('actions-toolkit')
 const fm = require('front-matter')
 const nunjucks = require('nunjucks')
 const dateFilter = require('nunjucks-date-filter')
 
 class IssueCreator {
-  constructor (template) {
-    this.template = template || '.github/ISSUE_TEMPLATE.md'
-    this.tools = new Toolkit()
+  /**
+   * @param {import('actions-toolkit').Toolkit} tools
+   */
+  constructor (tools) {
+    const args = tools.arguments._
+    this.template = args[0] || '.github/ISSUE_TEMPLATE.md'
     this.env = nunjucks.configure({ autoescape: false })
     this.env.addFilter('date', dateFilter)
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ class IssueCreator {
    * @param {import('actions-toolkit').Toolkit} tools
    */
   constructor (tools) {
-    this.template = tools.arguments._[0] || '.github/ISSUE_TEMPLATE.md'
+    this.tools = tools
+    this.template = this.tools.arguments._[0] || '.github/ISSUE_TEMPLATE.md'
     this.env = nunjucks.configure({ autoescape: false })
     this.env.addFilter('date', dateFilter)
   }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ class IssueCreator {
    * @param {import('actions-toolkit').Toolkit} tools
    */
   constructor (tools) {
-    const args = tools.arguments._
-    this.template = args[0] || '.github/ISSUE_TEMPLATE.md'
+    this.template = tools.arguments._[0] || '.github/ISSUE_TEMPLATE.md'
     this.env = nunjucks.configure({ autoescape: false })
     this.env.addFilter('date', dateFilter)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,14 +87,15 @@
       "dev": true
     },
     "actions-toolkit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-0.0.3.tgz",
-      "integrity": "sha512-tKwaooQl+X4bhGdgNGQKnTIDStLmLv89na03mLrY6RJA3uBdHFqI2O5N3LzYFjmJC91MTxPs5SHYRXgjT7q1BQ==",
+      "version": "0.0.5-0",
+      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-0.0.5-0.tgz",
+      "integrity": "sha512-Zactf1XnKjLt+inicnK4aNvtldidezFpjGEdjFyiNo/urivbwM8ABoJ/TyqIMhsjMwP29LKtmD2XoMQxOtS/Ug==",
       "requires": {
         "@octokit/rest": "^15.15.1",
         "execa": "^1.0.0",
         "js-yaml": "^3.12.0",
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.0",
+        "winston": "^3.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -265,7 +266,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -947,11 +947,19 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -959,8 +967,35 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colors": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+    },
+    "colorspace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
+      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -1233,6 +1268,16 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1267,6 +1312,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1274,6 +1327,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1908,6 +1966,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -1916,6 +1979,11 @@
       "requires": {
         "bser": "^2.0.0"
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
       "version": "2.0.0",
@@ -4509,6 +4577,14 @@
       "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -4593,6 +4669,18 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "logform": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
+      "integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.2.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4976,6 +5064,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "2.0.1",
@@ -5812,6 +5905,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -6035,6 +6143,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stack-utils": {
       "version": "1.0.1",
@@ -6362,6 +6475,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6471,6 +6589,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6779,6 +6902,31 @@
             "strip-eof": "^1.0.0"
           }
         }
+      }
+    },
+    "winston": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.1.0.tgz",
+      "integrity": "sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==",
+      "requires": {
+        "async": "^2.6.0",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^1.9.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^2.3.6",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.2.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
+      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "actions-toolkit": "0.0.3",
+    "actions-toolkit": "0.0.5-0",
     "front-matter": "^3.0.1",
     "js-yaml": "^3.12.0",
     "nunjucks": "^3.1.4",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,18 +1,19 @@
 const path = require('path')
 const IssueCreator = require('..')
-const Toolkit = require('actions-toolkit')
+const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
   let issueCreator, tools, github
 
   beforeEach(() => {
     tools = new Toolkit()
-    issueCreator = new IssueCreator(tools)
     github = { issues: { create: jest.fn() } }
 
-    issueCreator.tools.workspace = path.join(__dirname, 'fixtures')
-    issueCreator.tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
-    issueCreator.tools.github = github
+    tools.workspace = path.join(__dirname, 'fixtures')
+    tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
+    tools.github = github
+
+    issueCreator = new IssueCreator(tools)
   })
 
   it('creates a new issue', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,11 +1,13 @@
 const path = require('path')
 const IssueCreator = require('..')
+const Toolkit = require('actions-toolkit')
 
 describe('create-an-issue', () => {
-  let issueCreator, github
+  let issueCreator, tools, github
 
   beforeEach(() => {
-    issueCreator = new IssueCreator()
+    tools = new Toolkit()
+    issueCreator = new IssueCreator(tools)
     github = { issues: { create: jest.fn() } }
 
     issueCreator.tools.workspace = path.join(__dirname, 'fixtures')
@@ -20,7 +22,8 @@ describe('create-an-issue', () => {
   })
 
   it('creates a new issue from a different template', async () => {
-    issueCreator = new IssueCreator('.github/different-template.md')
+    tools.arguments._ = ['.github/different-template.md']
+    issueCreator = new IssueCreator(tools)
     issueCreator.tools.workspace = path.join(__dirname, 'fixtures')
     issueCreator.tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
     issueCreator.tools.createOctokit = jest.fn(() => github)


### PR DESCRIPTION
Tiny improvement, this PR makes use of `Toolkit.arguments` instead of manually getting the template name off of `process.argv`.