### PR TITLE
Make it not broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:10-alpine
 
 LABEL "com.github.actions.name"="Create an issue"
 LABEL "com.github.actions.description"="Creates a new issue using a template with front matter."

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,5 +1,5 @@
+const { Toolkit } = require('actions-toolkit')
 const IssueCreator = require('.')
-const Toolkit = require('actions-toolkit')
 
 const tools = new Toolkit()
 const issueCreator = new IssueCreator(tools)

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -5,5 +5,5 @@ const tools = new Toolkit()
 const issueCreator = new IssueCreator(tools)
 issueCreator.go()
   .then(issue => {
-    tools.log(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+    tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   })


### PR DESCRIPTION
Pointed out in #3, this PR fixes a bug where in the `entrypoint.js` file (a file that isn't covered by the tests), we're importing Toolkit as a default export, but it should be a named export:

```diff
- const Toolkit = require('actions-toolkit')
+ const { Toolkit } = require('actions-toolkit')
```

I'll take a look at minimizing the work in `entrypoint.js` to avoid things like this in the future.

Closes #3 