### PR TITLE
actions-toolkit@2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY package*.json ./
 RUN npm ci
 COPY . .
 
-ENTRYPOINT ["node", "/entrypoint.js"]
+ENTRYPOINT ["node", "/index.js"]

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,9 +1,0 @@
-const { Toolkit } = require('actions-toolkit')
-const IssueCreator = require('.')
-
-const tools = new Toolkit()
-const issueCreator = new IssueCreator(tools)
-issueCreator.go()
-  .then(issue => {
-    tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
-  })

--- a/index.js
+++ b/index.js
@@ -36,12 +36,13 @@ class IssueCreator {
     this.tools.log('Creating new issue')
 
     // Create the new issue
-    return this.tools.github.issues.create(this.tools.context.repo({
+    return this.tools.github.issues.create({
+      ...this.tools.context.repo,
       ...templated,
       assignees: attributes.assignees || [],
       labels: attributes.labels || [],
       milestone: attributes.milestone
-    }))
+    })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,9 +222,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.20.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.20.0.tgz",
-      "integrity": "sha512-tN5j64P6QymlMzKo94DG1LRNHCwMnLg5poZlVhsCfkHhEWKpofZ1qBDr2/0w6qDLav4EA1XXMmZdNpvGhc9BDQ==",
+      "version": "16.22.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.22.0.tgz",
+      "integrity": "sha512-1PGUwDxLuG7AZsiKaIdxJr918jcZ1FtPX0kGqxoUlssn+fIzzlwQY623gnM8vY9c9jfASD+QUQmflHh3FwBthw==",
       "requires": {
         "@octokit/request": "2.4.2",
         "before-after-hook": "^1.4.0",
@@ -279,17 +279,18 @@
       "dev": true
     },
     "actions-toolkit": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-2.0.0-beta.1.tgz",
-      "integrity": "sha512-gXEgvXz8+9dGZUie32QnzuMsi6SN3lnuBtqugGrSqqc91HJ+SoUFNQZvGWEaV/fzZso7pCPMc5WTmRjGz7Y0TA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-2.0.0.tgz",
+      "integrity": "sha512-wzQa0KkN0IUrJdl72hLV1a/oOAUpKLriETV5+/85T6sLfCaIJJQ3YUMtKDc1ctjfsdRfvYO8Qst8OOVi64boKw==",
       "requires": {
         "@octokit/graphql": "^2.0.1",
         "@octokit/rest": "^16.15.0",
+        "enquirer": "^2.3.0",
         "execa": "^1.0.0",
         "flat-cache": "^2.0.1",
-        "js-yaml": "^3.12.1",
+        "js-yaml": "^3.13.0",
         "minimist": "^1.2.0",
-        "signale": "^1.3.0"
+        "signale": "^1.4.0"
       },
       "dependencies": {
         "flat-cache": {
@@ -351,6 +352,11 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -1369,6 +1375,14 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.0.tgz",
+      "integrity": "sha512-RNGUbRVlfnjmpxV+Ed+7CGu0rg3MK7MmlW+DW0v7V2zdAUBC1s4BxCRiIAozbYB2UJ+q4D+8tW9UFb11kF72/g==",
+      "requires": {
+        "ansi-colors": "^3.2.1"
       }
     },
     "error-ex": {
@@ -4243,9 +4257,9 @@
       }
     },
     "macos-release": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
-      "integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
     },
     "make-dir": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,9 +279,9 @@
       "dev": true
     },
     "actions-toolkit": {
-      "version": "2.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-2.0.0-beta.0.tgz",
-      "integrity": "sha512-ZGO90e9NCBsPB+TEWrijXQ7CyVwkZxItMn/NLQFxhUYoULhUrz4zda/UK1lRUcwTEKv6ncQofcgB8rK447Fc/g==",
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-2.0.0-beta.1.tgz",
+      "integrity": "sha512-gXEgvXz8+9dGZUie32QnzuMsi6SN3lnuBtqugGrSqqc91HJ+SoUFNQZvGWEaV/fzZso7pCPMc5WTmRjGz7Y0TA==",
       "requires": {
         "@octokit/graphql": "^2.0.1",
         "@octokit/rest": "^16.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,9 +189,9 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-      "integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz",
+      "integrity": "sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==",
       "requires": {
         "deepmerge": "3.2.0",
         "is-plain-object": "^2.0.4",
@@ -200,36 +200,41 @@
       }
     },
     "@octokit/graphql": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.0.1.tgz",
-      "integrity": "sha512-IBNr05yBYqffy9L37Vv3/5xQMw+swmYFtMsuwqUA5vSEUr+s/POf8DOpCaTtS8f7e9k+cEuKLC5AbOoXkdZZOA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.0.2.tgz",
+      "integrity": "sha512-q3h3WWpGKkizPChhysKhy1uGdyjTsS7THTweIap3EWG5e3FQufXy1m7UPgKV3VpXHYZuBbX+k0paD213igiLuw==",
       "requires": {
-        "@octokit/request": "^2.1.2"
+        "@octokit/request": "^2.4.0",
+        "universal-user-agent": "^2.0.3"
       }
     },
     "@octokit/request": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz",
-      "integrity": "sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz",
+      "integrity": "sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==",
       "requires": {
-        "@octokit/endpoint": "^3.1.1",
+        "@octokit/endpoint": "^3.2.0",
+        "deprecation": "^1.0.1",
         "is-plain-object": "^2.0.4",
         "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.1"
       }
     },
     "@octokit/rest": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz",
-      "integrity": "sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==",
+      "version": "16.20.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.20.0.tgz",
+      "integrity": "sha512-tN5j64P6QymlMzKo94DG1LRNHCwMnLg5poZlVhsCfkHhEWKpofZ1qBDr2/0w6qDLav4EA1XXMmZdNpvGhc9BDQ==",
       "requires": {
-        "@octokit/request": "2.3.0",
-        "before-after-hook": "^1.2.0",
+        "@octokit/request": "2.4.2",
+        "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
+        "deprecation": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
@@ -274,15 +279,15 @@
       "dev": true
     },
     "actions-toolkit": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-1.5.0.tgz",
-      "integrity": "sha512-nYNPJR9jNdSPfMftKaAcDq8G9WRApCAFG+W8PiOuHiksXtltvrFio7/oL8oJL3EdQJwxL98k0nLb4tV4qO+EJw==",
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/actions-toolkit/-/actions-toolkit-2.0.0-beta.0.tgz",
+      "integrity": "sha512-ZGO90e9NCBsPB+TEWrijXQ7CyVwkZxItMn/NLQFxhUYoULhUrz4zda/UK1lRUcwTEKv6ncQofcgB8rK447Fc/g==",
       "requires": {
         "@octokit/graphql": "^2.0.1",
-        "@octokit/rest": "^16.13.3",
+        "@octokit/rest": "^16.15.0",
         "execa": "^1.0.0",
         "flat-cache": "^2.0.1",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.12.1",
         "minimist": "^1.2.0",
         "signale": "^1.3.0"
       },
@@ -297,9 +302,18 @@
             "write": "1.0.3"
           }
         },
+        "js-yaml": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "rimraf": {
@@ -398,7 +412,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -734,9 +748,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -1303,6 +1317,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "deprecation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg=="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2069,7 +2088,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2087,11 +2107,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2104,15 +2126,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2215,7 +2240,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2225,6 +2251,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2237,17 +2264,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2264,6 +2294,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2336,7 +2367,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2346,6 +2378,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2421,7 +2454,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2451,6 +2485,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2468,6 +2503,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2506,11 +2542,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2540,7 +2578,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -2999,7 +3037,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -4204,9 +4243,9 @@
       }
     },
     "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
+      "integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw=="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -5299,7 +5338,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5368,9 +5407,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "signale": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/signale/-/signale-1.3.0.tgz",
-      "integrity": "sha512-TyFhsQ9wZDYDfsPqWMyjCxsDoMwfpsT0130Mce7wDiVCSDdtWSg83dOqoj8aGpGCs3n1YPcam6sT1OFPuGT/OQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "requires": {
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
@@ -6216,7 +6255,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "actions-toolkit": "^2.0.0-beta.1",
+    "actions-toolkit": "^2.0.0",
     "front-matter": "^3.0.1",
     "js-yaml": "^3.12.0",
     "nunjucks": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "actions-toolkit": "^1.5.0",
+    "actions-toolkit": "^2.0.0-beta.0",
     "front-matter": "^3.0.1",
     "js-yaml": "^3.12.0",
     "nunjucks": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "actions-toolkit": "^2.0.0-beta.0",
+    "actions-toolkit": "^2.0.0-beta.1",
     "front-matter": "^3.0.1",
     "js-yaml": "^3.12.0",
     "nunjucks": "^3.1.4",

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -16,6 +16,14 @@ Array [
 ]
 `;
 
+exports[`create-an-issue creates a new issue 2`] = `
+Array [
+  Array [
+    "Created issue Hello!#1: www",
+  ],
+]
+`;
+
 exports[`create-an-issue creates a new issue with assignees, labels and a milestone 1`] = `
 Array [
   Array [

--- a/tests/fixtures/event.json
+++ b/tests/fixtures/event.json
@@ -1,0 +1,6 @@
+{
+  "repository": {
+    "owner": { "login": "JasonEtco" },
+    "name": "waddup"
+  }
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,65 +1,51 @@
 const path = require('path')
-const IssueCreator = require('..')
+const { Signale } = require('signale')
 const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
-  let issueCreator, tools, github
+  let actionFn, tools
 
   beforeEach(() => {
+    Toolkit.run = jest.fn(fn => { actionFn = fn })
+    require('..')
+
     Object.assign(process.env, {
       GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'event.json'),
-      GITHUB_WORKSPACE: path.join(__dirname, 'fixtures'),
-      GITHUB_WORKFLOW: 'GITHUB_WORKFLOW',
-      GITHUB_ACTION: 'GITHUB_ACTION',
-      GITHUB_ACTOR: 'GITHUB_ACTOR',
-      GITHUB_REPOSITORY: 'GITHUB_REPOSITORY',
-      GITHUB_EVENT_NAME: 'GITHUB_EVENT_NAME',
-      GITHUB_SHA: 'GITHUB_SHA',
-      GITHUB_REF: 'GITHUB_REF'
+      GITHUB_WORKSPACE: path.join(__dirname, 'fixtures')
     })
 
-    tools = new Toolkit({
-      logger: {
-        info: jest.fn(),
-        warn: jest.fn()
-      }
-    })
-
-    github = { issues: { create: jest.fn() } }
-    tools.github = github
-
-    issueCreator = new IssueCreator(tools)
+    tools = new Toolkit({ logger: new Signale({ disabled: true }) })
+    tools.github = { issues: { create: jest.fn(({ title }) => Promise.resolve({ data: { number: 1, title, html_url: 'www' } })) } }
+    tools.exit.success = jest.fn()
+    tools.exit.failure = jest.fn()
   })
 
   it('creates a new issue', async () => {
-    await issueCreator.go()
-    expect(github.issues.create).toHaveBeenCalled()
-    expect(github.issues.create.mock.calls).toMatchSnapshot()
+    await actionFn(tools)
+    expect(tools.github.issues.create).toHaveBeenCalled()
+    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue from a different template', async () => {
     tools.arguments._ = ['.github/different-template.md']
-    issueCreator = new IssueCreator(tools)
-    issueCreator.tools.workspace = path.join(__dirname, 'fixtures')
-    issueCreator.tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
-    issueCreator.tools.github = github
-
-    await issueCreator.go()
-    expect(github.issues.create).toHaveBeenCalled()
-    expect(github.issues.create.mock.calls[0][0].title).toBe('Different file')
+    tools.workspace = path.join(__dirname, 'fixtures')
+    tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
+    await actionFn(tools)
+    expect(tools.github.issues.create).toHaveBeenCalled()
+    expect(tools.github.issues.create.mock.calls[0][0].title).toBe('Different file')
   })
 
   it('creates a new issue with some template variables', async () => {
-    issueCreator.template = '.github/variables.md'
-    await issueCreator.go()
-    expect(github.issues.create).toHaveBeenCalled()
-    expect(github.issues.create.mock.calls).toMatchSnapshot()
+    tools.arguments._[0] = '.github/variables.md'
+    await actionFn(tools)
+    expect(tools.github.issues.create).toHaveBeenCalled()
+    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue with assignees, labels and a milestone', async () => {
-    issueCreator.template = '.github/kitchen-sink.md'
-    await issueCreator.go()
-    expect(github.issues.create).toHaveBeenCalled()
-    expect(github.issues.create.mock.calls).toMatchSnapshot()
+    tools.arguments._[0] = '.github/kitchen-sink.md'
+    await actionFn(tools)
+    expect(tools.github.issues.create).toHaveBeenCalled()
+    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
   })
 })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -15,15 +15,26 @@ describe('create-an-issue', () => {
     })
 
     tools = new Toolkit({ logger: new Signale({ disabled: true }) })
-    tools.github = { issues: { create: jest.fn(({ title }) => Promise.resolve({ data: { number: 1, title, html_url: 'www' } })) } }
+    tools.github = {
+      issues: {
+        create: jest.fn(({ title }) => Promise.resolve({ data: {
+          title,
+          number: 1,
+          html_url: 'www'
+        } }))
+      }
+    }
     tools.exit.success = jest.fn()
     tools.exit.failure = jest.fn()
   })
 
   it('creates a new issue', async () => {
+    tools.log.success = jest.fn()
     await actionFn(tools)
     expect(tools.github.issues.create).toHaveBeenCalled()
     expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
+    expect(tools.log.success).toHaveBeenCalled()
+    expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue from a different template', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,16 +6,26 @@ describe('create-an-issue', () => {
   let issueCreator, tools, github
 
   beforeEach(() => {
+    Object.assign(process.env, {
+      GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'event.json'),
+      GITHUB_WORKSPACE: path.join(__dirname, 'fixtures'),
+      GITHUB_WORKFLOW: 'GITHUB_WORKFLOW',
+      GITHUB_ACTION: 'GITHUB_ACTION',
+      GITHUB_ACTOR: 'GITHUB_ACTOR',
+      GITHUB_REPOSITORY: 'GITHUB_REPOSITORY',
+      GITHUB_EVENT_NAME: 'GITHUB_EVENT_NAME',
+      GITHUB_SHA: 'GITHUB_SHA',
+      GITHUB_REF: 'GITHUB_REF'
+    })
+
     tools = new Toolkit({
       logger: {
         info: jest.fn(),
         warn: jest.fn()
       }
     })
-    github = { issues: { create: jest.fn() } }
 
-    tools.workspace = path.join(__dirname, 'fixtures')
-    tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
+    github = { issues: { create: jest.fn() } }
     tools.github = github
 
     issueCreator = new IssueCreator(tools)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const { Signale } = require('signale')
 const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
@@ -14,7 +13,11 @@ describe('create-an-issue', () => {
       GITHUB_WORKSPACE: path.join(__dirname, 'fixtures')
     })
 
-    tools = new Toolkit({ logger: new Signale({ disabled: true }) })
+    tools = new Toolkit({ logger: {
+      info: jest.fn(),
+      success: jest.fn(),
+      warn: jest.fn()
+    } })
     tools.github = {
       issues: {
         create: jest.fn(({ title }) => Promise.resolve({ data: {


### PR DESCRIPTION
This PR updates `actions-toolkit` to `2.0.0`. There are a couple of breaking changes, outlined [in this release](https://github.com/JasonEtco/actions-toolkit/releases/tag/v2.0.0-beta.0). Right now I'm using the `@beta` tag until we're all set with the 2.0.0 release - and I'm using this as a way to validate the upgrade steps and make sure that its all good.

Follow along: https://github.com/JasonEtco/actions-toolkit/pull/62.