### PR TITLE
Use GITHUB_REPOSITORY instead of context.repo()

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,12 +36,15 @@ class IssueCreator {
     this.tools.log('Creating new issue')
 
     // Create the new issue
-    return this.tools.github.issues.create(this.tools.context.repo({
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
+    return this.tools.github.issues.create({
+      owner,
+      repo,
       ...templated,
       assignees: attributes.assignees || [],
       labels: attributes.labels || [],
       milestone: attributes.milestone
-    }))
+    })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -398,7 +398,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2069,7 +2069,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2087,11 +2088,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2104,15 +2107,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2215,7 +2221,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2225,6 +2232,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2237,17 +2245,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2264,6 +2275,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2336,7 +2348,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2346,6 +2359,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2421,7 +2435,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2451,6 +2466,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2468,6 +2484,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2506,11 +2523,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2999,7 +3018,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -5299,7 +5319,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -6216,7 +6236,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,10 @@
     "env": [
       "jest"
     ]
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/tests/setup.js"
+    ]
   }
 }

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -23,7 +23,7 @@ Array [
       "assignees": Array [
         "JasonEtco",
       ],
-      "body": "The repo waddup is the best repo.",
+      "body": "The action create-an-issue is the best action.",
       "labels": Array [
         "bugs",
       ],
@@ -41,12 +41,12 @@ Array [
   Array [
     Object {
       "assignees": Array [],
-      "body": "The repo waddup is the best repo.",
+      "body": "The action create-an-issue is the best action.",
       "labels": Array [],
       "milestone": undefined,
       "owner": "JasonEtco",
       "repo": "waddup",
-      "title": "Hello JasonEtco",
+      "title": "Hello create-an-issue",
     },
   ],
 ]

--- a/tests/fixtures/.github/kitchen-sink.md
+++ b/tests/fixtures/.github/kitchen-sink.md
@@ -6,4 +6,4 @@ labels:
   - bugs
 milestone: 2
 ---
-The repo {{ payload.repository.name }} is the best repo.
+The action {{ action }} is the best action.

--- a/tests/fixtures/.github/variables.md
+++ b/tests/fixtures/.github/variables.md
@@ -1,4 +1,4 @@
 ---
-title: Hello {{ payload.repository.owner.login }}
+title: Hello {{ action }}
 ---
-The repo {{ payload.repository.name }} is the best repo.
+The action {{ action }} is the best action.

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -15,7 +15,6 @@ describe('create-an-issue', () => {
     github = { issues: { create: jest.fn() } }
 
     tools.workspace = path.join(__dirname, 'fixtures')
-    tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
     tools.github = github
 
     issueCreator = new IssueCreator(tools)

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,4 @@
+Object.assign(process.env, {
+  'GITHUB_REPOSITORY': 'JasonEtco/waddup',
+  'GITHUB_ACTION': 'create-an-issue'
+})


### PR DESCRIPTION
Turns out that not every event comes with a repository object on the payload, but we can rely on the `GITHUB_REPOSITORY` environment variable instead.