### PR TITLE
Rewrite tests in nock

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Toolkit.run(async tools => {
   }
 
   // Get the file
-  tools.log('Reading from file', template)
+  tools.log.debug('Reading from file', template)
   const file = tools.getFile(template)
 
   // Grab the front matter as JSON
@@ -26,8 +26,8 @@ Toolkit.run(async tools => {
     title: env.renderString(attributes.title, templateVariables)
   }
 
-  tools.log('Templates compiled', templated)
-  tools.log('Creating new issue')
+  tools.log.debug('Templates compiled', templated)
+  tools.log.info(`Creating new issue ${templated.title}`)
 
   // Create the new issue
   const issue = await tools.github.issues.create({

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,7 +314,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "rimraf": {
@@ -476,6 +476,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -900,6 +906,20 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -932,6 +952,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -1215,6 +1241,21 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2584,6 +2625,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -2592,7 +2639,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -4460,6 +4507,34 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
@@ -4831,6 +4906,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -5010,6 +5091,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.31",
@@ -6064,6 +6151,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "jest": "^24.1.0",
+    "nock": "^10.0.6",
     "standard": "^12.0.1"
   },
   "standard": {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,19 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`create-an-issue creates a new issue 1`] = `
-Array [
-  Array [
-    Object {
-      "assignees": Array [],
-      "body": "Goodbye!",
-      "labels": Array [],
-      "milestone": undefined,
-      "owner": "JasonEtco",
-      "repo": "waddup",
-      "title": "Hello!",
-    },
-  ],
-]
+Object {
+  "assignees": Array [],
+  "body": "Goodbye!",
+  "labels": Array [],
+  "title": "Hello!",
+}
 `;
 
 exports[`create-an-issue creates a new issue 2`] = `
@@ -24,22 +17,41 @@ Array [
 ]
 `;
 
-exports[`create-an-issue creates a new issue with assignees, labels and a milestone 1`] = `
+exports[`create-an-issue creates a new issue from a different template 1`] = `
+Object {
+  "assignees": Array [],
+  "body": "Goodbye!",
+  "labels": Array [],
+  "title": "Different file",
+}
+`;
+
+exports[`create-an-issue creates a new issue from a different template 2`] = `
 Array [
   Array [
-    Object {
-      "assignees": Array [
-        "JasonEtco",
-      ],
-      "body": "The action create-an-issue is the best action.",
-      "labels": Array [
-        "bugs",
-      ],
-      "milestone": 2,
-      "owner": "JasonEtco",
-      "repo": "waddup",
-      "title": "DO EVERYTHING",
-    },
+    "Created issue Different file#1: www",
+  ],
+]
+`;
+
+exports[`create-an-issue creates a new issue with assignees, labels and a milestone 1`] = `
+Object {
+  "assignees": Array [
+    "JasonEtco",
+  ],
+  "body": "The action create-an-issue is the best action.",
+  "labels": Array [
+    "bugs",
+  ],
+  "milestone": 2,
+  "title": "DO EVERYTHING",
+}
+`;
+
+exports[`create-an-issue creates a new issue with assignees, labels and a milestone 2`] = `
+Array [
+  Array [
+    "Created issue DO EVERYTHING#1: www",
   ],
 ]
 `;
@@ -47,15 +59,7 @@ Array [
 exports[`create-an-issue creates a new issue with some template variables 1`] = `
 Array [
   Array [
-    Object {
-      "assignees": Array [],
-      "body": "The action create-an-issue is the best action.",
-      "labels": Array [],
-      "milestone": undefined,
-      "owner": "JasonEtco",
-      "repo": "waddup",
-      "title": "Hello create-an-issue",
-    },
+    "Created issue Hello create-an-issue#1: www",
   ],
 ]
 `;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2,18 +2,21 @@ const nock = require('nock')
 const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
-  let actionFn, tools, scoped
+  let actionFn, tools, params
 
   beforeEach(() => {
     Toolkit.run = jest.fn(fn => { actionFn = fn })
     require('..')
 
-    scoped = nock('https://api.github.com')
-      .post(/\/repos\/.*\/.*\/issues/).reply(200, (_, body) => ({
-        title: body.title,
-        number: 1,
-        html_url: 'www'
-      }))
+    nock('https://api.github.com')
+      .post(/\/repos\/.*\/.*\/issues/).reply(200, (_, body) => {
+        params = JSON.parse(body)
+        return {
+          title: params.title,
+          number: 1,
+          html_url: 'www'
+        }
+      })
 
     tools = new Toolkit({
       logger: {
@@ -31,6 +34,7 @@ describe('create-an-issue', () => {
   it('creates a new issue', async () => {
     tools.log.success = jest.fn()
     await actionFn(tools)
+    expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
@@ -39,6 +43,7 @@ describe('create-an-issue', () => {
     tools.arguments._ = ['.github/different-template.md']
     tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
     await actionFn(tools)
+    expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
@@ -46,13 +51,14 @@ describe('create-an-issue', () => {
   it('creates a new issue with some template variables', async () => {
     tools.arguments._[0] = '.github/variables.md'
     await actionFn(tools)
-    expect(tools.github.issues.create).toHaveBeenCalled()
-    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
+    expect(tools.log.success).toHaveBeenCalled()
+    expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue with assignees, labels and a milestone', async () => {
     tools.arguments._[0] = '.github/kitchen-sink.md'
     await actionFn(tools)
+    expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,32 +1,29 @@
-const path = require('path')
+const nock = require('nock')
 const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
-  let actionFn, tools
+  let actionFn, tools, scoped
 
   beforeEach(() => {
     Toolkit.run = jest.fn(fn => { actionFn = fn })
     require('..')
 
-    Object.assign(process.env, {
-      GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'event.json'),
-      GITHUB_WORKSPACE: path.join(__dirname, 'fixtures')
+    scoped = nock('https://api.github.com')
+      .post(/\/repos\/.*\/.*\/issues/).reply(200, (_, body) => ({
+        title: body.title,
+        number: 1,
+        html_url: 'www'
+      }))
+
+    tools = new Toolkit({
+      logger: {
+        info: jest.fn(),
+        success: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn()
+      }
     })
 
-    tools = new Toolkit({ logger: {
-      info: jest.fn(),
-      success: jest.fn(),
-      warn: jest.fn()
-    } })
-    tools.github = {
-      issues: {
-        create: jest.fn(({ title }) => Promise.resolve({ data: {
-          title,
-          number: 1,
-          html_url: 'www'
-        } }))
-      }
-    }
     tools.exit.success = jest.fn()
     tools.exit.failure = jest.fn()
   })
@@ -34,19 +31,16 @@ describe('create-an-issue', () => {
   it('creates a new issue', async () => {
     tools.log.success = jest.fn()
     await actionFn(tools)
-    expect(tools.github.issues.create).toHaveBeenCalled()
-    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue from a different template', async () => {
     tools.arguments._ = ['.github/different-template.md']
-    tools.workspace = path.join(__dirname, 'fixtures')
     tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
     await actionFn(tools)
-    expect(tools.github.issues.create).toHaveBeenCalled()
-    expect(tools.github.issues.create.mock.calls[0][0].title).toBe('Different file')
+    expect(tools.log.success).toHaveBeenCalled()
+    expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue with some template variables', async () => {
@@ -59,7 +53,7 @@ describe('create-an-issue', () => {
   it('creates a new issue with assignees, labels and a milestone', async () => {
     tools.arguments._[0] = '.github/kitchen-sink.md'
     await actionFn(tools)
-    expect(tools.github.issues.create).toHaveBeenCalled()
-    expect(tools.github.issues.create.mock.calls).toMatchSnapshot()
+    expect(tools.log.success).toHaveBeenCalled()
+    expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 })

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,8 @@
+const path = require('path')
+
 Object.assign(process.env, {
-  'GITHUB_REPOSITORY': 'JasonEtco/waddup',
-  'GITHUB_ACTION': 'create-an-issue'
+  GITHUB_REPOSITORY: 'JasonEtco/waddup',
+  GITHUB_ACTION: 'create-an-issue',
+  GITHUB_EVENT_PATH: path.join(__dirname, 'fixtures', 'event.json'),
+  GITHUB_WORKSPACE: path.join(__dirname, 'fixtures')
 })


### PR DESCRIPTION
I want to make use of some of the internal validation functionality of `@octokit/rest` methods, which means that I can't continue to mock those methods in tests without mocking the validation as well. So, this PR refactors the testing setup to use `nock`.

I've also swapped some log levels around to be a little more clear about their reason for existing.