### PR TITLE
Throw helpful error when issue creation fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,20 @@ Toolkit.run(async tools => {
   tools.log.info(`Creating new issue ${templated.title}`)
 
   // Create the new issue
-  const issue = await tools.github.issues.create({
-    ...tools.context.repo,
-    ...templated,
-    assignees: listToArray(attributes.assignees),
-    labels: listToArray(attributes.labels),
-    milestone: attributes.milestone
-  })
+  try {
+    const issue = await tools.github.issues.create({
+      ...tools.context.repo,
+      ...templated,
+      assignees: listToArray(attributes.assignees),
+      labels: listToArray(attributes.labels),
+      milestone: attributes.milestone
+    })
 
-  tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+    tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
+  } catch (err) {
+    tools.log.error(`An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check ${template}!`, err)
+    tools.exit.failure()
+  }
 }, {
   secrets: ['GITHUB_TOKEN']
 })

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ Toolkit.run(async tools => {
 
     tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   } catch (err) {
-    tools.log.error(`An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check ${template}!`, err)
+    tools.log.error(`An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check ${template}!`)
+    tools.log.error(err)
     tools.exit.failure()
   }
 }, {

--- a/index.js
+++ b/index.js
@@ -46,8 +46,14 @@ Toolkit.run(async tools => {
 
     tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   } catch (err) {
+    // Log the error message
     tools.log.error(`An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check ${template}!`)
     tools.log.error(err)
+
+    // The error might have more details
+    if (err.errors) tools.log.error(err.errors)
+
+    // Exit with a failing status
     tools.exit.failure()
   }
 }, {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -86,3 +86,12 @@ Array [
   ],
 ]
 `;
+
+exports[`create-an-issue logs a helpful error if creating an issue throws an error 1`] = `
+Array [
+  Array [
+    "An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE.md!",
+    [HttpError: request to https://api.github.com/repos/JasonEtco/waddup/issues failed, reason: Oh no something borked!],
+  ],
+]
+`;

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -93,7 +93,25 @@ Array [
     "An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE.md!",
   ],
   Array [
-    [HttpError: request to https://api.github.com/repos/JasonEtco/waddup/issues failed, reason: Oh no something borked!],
+    [HttpError: Validation error],
+  ],
+]
+`;
+
+exports[`create-an-issue logs a helpful error if creating an issue throws an error with more errors 1`] = `
+Array [
+  Array [
+    "An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE.md!",
+  ],
+  Array [
+    [HttpError: Validation error],
+  ],
+  Array [
+    Array [
+      Object {
+        "foo": true,
+      },
+    ],
   ],
 ]
 `;

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -91,6 +91,8 @@ exports[`create-an-issue logs a helpful error if creating an issue throws an err
 Array [
   Array [
     "An error occurred while creating the issue. This might be caused by a malformed issue title, or a typo in the labels or assignees. Check .github/ISSUE_TEMPLATE.md!",
+  ],
+  Array [
     [HttpError: request to https://api.github.com/repos/JasonEtco/waddup/issues failed, reason: Oh no something borked!],
   ],
 ]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -75,7 +75,24 @@ describe('create-an-issue', () => {
   it('logs a helpful error if creating an issue throws an error', async () => {
     nock.cleanAll()
     nock('https://api.github.com')
-      .post(/\/repos\/.*\/.*\/issues/).replyWithError('Oh no something borked!')
+      .post(/\/repos\/.*\/.*\/issues/).reply(500, {
+        message: 'Validation error'
+      })
+
+    await actionFn(tools)
+    expect(tools.log.error).toHaveBeenCalled()
+    expect(tools.log.error.mock.calls).toMatchSnapshot()
+    expect(tools.exit.failure).toHaveBeenCalled()
+  })
+
+  it('logs a helpful error if creating an issue throws an error with more errors', async () => {
+    nock.cleanAll()
+    nock('https://api.github.com')
+      .post(/\/repos\/.*\/.*\/issues/).reply(500, {
+        message: 'Validation error',
+        errors: [{ foo: true }]
+      })
+
     await actionFn(tools)
     expect(tools.log.error).toHaveBeenCalled()
     expect(tools.log.error.mock.calls).toMatchSnapshot()

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -23,7 +23,8 @@ describe('create-an-issue', () => {
         info: jest.fn(),
         success: jest.fn(),
         warn: jest.fn(),
-        debug: jest.fn()
+        debug: jest.fn(),
+        error: jest.fn()
       }
     })
 
@@ -69,5 +70,15 @@ describe('create-an-issue', () => {
     expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
+  })
+
+  it('logs a helpful error if creating an issue throws an error', async () => {
+    nock.cleanAll()
+    nock('https://api.github.com')
+      .post(/\/repos\/.*\/.*\/issues/).replyWithError('Oh no something borked!')
+    await actionFn(tools)
+    expect(tools.log.error).toHaveBeenCalled()
+    expect(tools.log.error.mock.calls).toMatchSnapshot()
+    expect(tools.exit.failure).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
When creating the issue fails, an unhelpful error message is logged. This can be for a lot of reasons, including malformed issue front-matter or trying to assign a user that doesn't exist. This PR logs a more helpful error message, as well as the error:

![image](https://user-images.githubusercontent.com/10660468/57160670-7623a100-6db7-11e9-884b-8155f08eb3e8.png)

cc @janester