### PR TITLE
Use inputs instead of args for custom filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This example will create a new issue with a title like **Weekly Radar Saturday, 
 
 ### Custom templates
 
-Don't want to use `.github/ISSUE_TEMPLATE.md`? You can pass an argument pointing the action to a different template:
+Don't want to use `.github/ISSUE_TEMPLATE.md`? You can pass an input pointing the action to a different template:
 
 ```yaml
 steps:
@@ -54,5 +54,5 @@ steps:
     env: 
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
-      args: .github/some-other-template.md
+      filename: .github/some-other-template.md
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,3 +6,7 @@ runs:
 branding:
   icon: alert-circle
   color: gray-dark
+inputs:
+  filename:
+    description: The name of the file to use as the issue template
+    default: .github/ISSUE_TEMPLATE.md

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core')
 const { Toolkit } = require('actions-toolkit')
 const fm = require('front-matter')
 const nunjucks = require('nunjucks')
@@ -9,7 +10,7 @@ function listToArray (list) {
 }
 
 Toolkit.run(async tools => {
-  const template = tools.arguments._[0] || '.github/ISSUE_TEMPLATE.md'
+  const template = core.getInput('filename') || '.github/ISSUE_TEMPLATE.md'
   const env = nunjucks.configure({ autoescape: false })
   env.addFilter('date', dateFilter)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,11 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-KKpo3xzo0Zsikni9tbOsEQkxZBGDsYSJZNkTvmo0gPSXrc98TBOcdTvKwwjitjkjHkreTggWdB1ACiAFVgsuzA=="
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -743,7 +748,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1249,7 +1254,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1412,7 +1417,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -4470,7 +4475,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4845,7 +4850,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -4862,7 +4867,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -4951,7 +4956,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -5191,7 +5196,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "optional": true,
       "requires": {
@@ -5422,7 +5427,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -5958,7 +5963,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -6020,7 +6025,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -6395,7 +6400,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -6422,7 +6427,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6483,7 +6488,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",
@@ -6515,7 +6520,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@actions/core": "^1.1.0",
     "actions-toolkit": "^2.2.0",
     "front-matter": "^3.0.2",
     "js-yaml": "^3.13.1",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -30,6 +30,9 @@ describe('create-an-issue', () => {
 
     tools.exit.success = jest.fn()
     tools.exit.failure = jest.fn()
+
+    // Ensure that the filename input isn't set at the start of a test
+    delete process.env.INPUT_FILENAME
   })
 
   it('creates a new issue', async () => {
@@ -41,7 +44,7 @@ describe('create-an-issue', () => {
   })
 
   it('creates a new issue from a different template', async () => {
-    tools.arguments._ = ['.github/different-template.md']
+    process.env.INPUT_FILENAME = '.github/different-template.md'
     tools.context.payload = { repository: { owner: { login: 'JasonEtco' }, name: 'waddup' } }
     await actionFn(tools)
     expect(params).toMatchSnapshot()
@@ -50,14 +53,14 @@ describe('create-an-issue', () => {
   })
 
   it('creates a new issue with some template variables', async () => {
-    tools.arguments._[0] = '.github/variables.md'
+    process.env.INPUT_FILENAME = '.github/variables.md'
     await actionFn(tools)
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 
   it('creates a new issue with assignees, labels and a milestone', async () => {
-    tools.arguments._[0] = '.github/kitchen-sink.md'
+    process.env.INPUT_FILENAME = '.github/kitchen-sink.md'
     await actionFn(tools)
     expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
@@ -65,7 +68,7 @@ describe('create-an-issue', () => {
   })
 
   it('creates a new issue with assignees and labels as comma-delimited strings', async () => {
-    tools.arguments._[0] = '.github/split-strings.md'
+    process.env.INPUT_FILENAME = '.github/split-strings.md'
     await actionFn(tools)
     expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()


### PR DESCRIPTION
In Actions v2, actions can have "inputs" - these are defined:

```yaml
uses: some/action
with:
  key: value
```

The official [actions/toolkit](https://github.com/actions/toolkit) has a method to get them: `core.getInput()`. Under the hood, those values are set as `process.env[`INPUT_${name.toUpperCase()}`] (hence the test changes).

This is a breaking change! It'll be released as v2.0.0 of this action.