### PR TITLE
Add checkout Action so the template can be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Don't want to use `.github/ISSUE_TEMPLATE.md`? You can pass an input pointing th
 
 ```yaml
 steps:
+  - uses: actions/checkout@master
   - uses: JasonEtco/create-an-issue@master
     env: 
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I found that creating an issue with a custom template failed because the file couldn't be found locally. Adding the checkout Action solved the problem for me, so I figured I'd submit a change for the docs.

I'm not sure if this is because I was working in a private repo or if it needs to be used in all cases 🤷‍♂ 