### PR TITLE
Add number and url outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,16 @@ steps:
     with:
       assignees: JasonEtco, octocat
 ```
+
+### URL output
+
+If you need the URL of the issue that was created for another Action, you can use the `url` output:
+
+```yaml
+steps:
+  - uses: JasonEtco/create-an-issue@master
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    id: create-issue
+  - run: 'echo Created ${{ steps.create-issue.outputs.url }}'
+```

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ steps:
       assignees: JasonEtco, octocat
 ```
 
-### URL output
+### Outputs
 
-If you need the URL of the issue that was created for another Action, you can use the `url` output:
+If you need the number or URL of the issue that was created for another Action, you can use the `number` or `url` outputs, respectively. For example:
 
 ```yaml
 steps:
@@ -82,5 +82,6 @@ steps:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     id: create-issue
+  - run: 'echo Created issue number ${{ steps.create-issue.outputs.number }}'
   - run: 'echo Created ${{ steps.create-issue.outputs.url }}'
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,3 +12,6 @@ inputs:
   filename:
     description: The name of the file to use as the issue template
     default: .github/ISSUE_TEMPLATE.md
+outputs:
+  url:
+    description: URL of the issue that was created

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,7 @@ inputs:
     description: The name of the file to use as the issue template
     default: .github/ISSUE_TEMPLATE.md
 outputs:
+  number:
+    description: Number of the issue that was created
   url:
     description: URL of the issue that was created

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ Toolkit.run(async tools => {
       milestone: attributes.milestone
     })
 
+    core.setOutput('number', issue.data.number)
     core.setOutput('url', issue.data.html_url)
     tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ Toolkit.run(async tools => {
       milestone: attributes.milestone
     })
 
+    core.setOutput('url', issue.data.html_url)
     tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   } catch (err) {
     // Log the error message

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const core = require('@actions/core')
 const { Toolkit } = require('actions-toolkit')
 
 describe('create-an-issue', () => {
@@ -28,6 +29,10 @@ describe('create-an-issue', () => {
       }
     })
 
+    // Turn core.setOutput into a mocked noop
+    jest.spyOn(core, 'setOutput')
+      .mockImplementation(() => {})
+
     tools.exit.success = jest.fn()
     tools.exit.failure = jest.fn()
 
@@ -41,6 +46,11 @@ describe('create-an-issue', () => {
     expect(params).toMatchSnapshot()
     expect(tools.log.success).toHaveBeenCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
+
+    // Verify that the outputs were set
+    expect(core.setOutput).toHaveBeenCalledTimes(2)
+    expect(core.setOutput).toHaveBeenCalledWith('url', 'www')
+    expect(core.setOutput).toHaveBeenCalledWith('number', 1)
   })
 
   it('creates a new issue from a different template', async () => {


### PR DESCRIPTION
* Adds a `url` output that contains the `html_url` for the issue that was created.
* Adds a `number` output that contains the number of the issue that was created.

I couldn't figure out how to hook this into the test framework since it seems all the mocking and such goes through `toolkit`, not `core`, so I didn't add any test code for it. If you've got some ideas, let me know and I'd be happy to add it.