### PR TITLE
Added support for templated assignees

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ Toolkit.run(async tools => {
 
   const templated = {
     body: env.renderString(body, templateVariables),
-    title: env.renderString(attributes.title, templateVariables)
+    title: env.renderString(attributes.title, templateVariables),
+    assignees: env.renderString(attributes.assignees, templateVariables)
   }
 
   tools.log.debug('Templates compiled', templated)
@@ -42,7 +43,7 @@ Toolkit.run(async tools => {
     const issue = await tools.github.issues.create({
       ...tools.context.repo,
       ...templated,
-      assignees: assignees ? listToArray(assignees) : listToArray(attributes.assignees),
+      assignees: assignees ? listToArray(assignees) : listToArray(templated.assignees),
       labels: listToArray(attributes.labels),
       milestone: tools.inputs.milestone || attributes.milestone
     })


### PR DESCRIPTION
Use case: Open a new issue if another issue is closed, under certain conditions.
Problem: We would want to retain the assignee from the original issue. Currently, this is not allowed.
Solution: This PR adds support for templated assignees. This way, `{{ mustache }}` case can be used and assignee can be made dynamic.