### PR TITLE
Fix readme wording for option to update existing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ steps:
       update_existing: true
 ```
 
-The `assignees` and `milestone` speak for themselves, the `update_existing` param can be passed and set to `true` when you want an existing open issue with the **exact same title** when it exists.
+The `assignees` and `milestone` speak for themselves, the `update_existing` param can be passed and set to `true` when you want to update an open issue with the **exact same title** when it exists.
 
 ### Outputs
 


### PR DESCRIPTION
I just came back to enable this in our repo, and spotted that the wording in the readme was slightly off. 