### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

I am the founder of [Step Security](https://www.stepsecurity.io), and have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a new PR is created that changes a workflow, or creates a new workflow, so feel free to [install it](https://github.com/apps/step-security) for future workflows, or try it out on other repos. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Thanks!