### PR TITLE
Skip updating an existing issue when update_existing=false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ steps:
       update_existing: true
 ```
 
-The `assignees` and `milestone` speak for themselves, the `update_existing` param can be passed and set to `true` when you want to update an open issue with the **exact same title** when it exists.
+The `assignees` and `milestone` speak for themselves, the `update_existing` param can be passed and set to `true` when you want to update an open issue with the **exact same title** when it exists and `false` if you don't want to create a new issue, but skip updating an existing one.
 
 ### Outputs
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -9,7 +9,16 @@ import { FrontMatterAttributes, listToArray, setOutputs } from './helpers'
 export async function createAnIssue (tools: Toolkit) {
   const template = tools.inputs.filename || '.github/ISSUE_TEMPLATE.md'
   const assignees = tools.inputs.assignees
-  const updateExisting: Boolean | null = tools.inputs.update_existing ? tools.inputs.update_existing === 'true' : null
+  let updateExisting: Boolean | null = null
+  if (tools.inputs.update_existing) {
+    if (tools.inputs.update_existing === 'true') {
+      updateExisting = true
+    } else if (tools.inputs.update_existing === 'false') {
+      updateExisting = false
+    } else {
+      tools.exit.failure(`Invalid value update_existing=${tools.inputs.update_existing}, must be one of true or false`)
+    }
+  }
   const env = nunjucks.configure({ autoescape: false })
   env.addFilter('date', dateFilter)
 
@@ -46,7 +55,7 @@ export async function createAnIssue (tools: Toolkit) {
       tools.exit.failure(err)
     }
     if (existingIssue) {
-      if (! updateExisting) {
+      if (updateExisting === false) {
         tools.exit.success(`Existing issue ${existingIssue.title}#${existingIssue.number}: ${existingIssue.html_url} found but not updated`)
       } else {
         try {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -184,6 +184,19 @@ Array [
 ]
 `;
 
+exports[`create-an-issue finds, but does not update an existing issue with the same title 1`] = `
+Object {
+  "assignees": Array [
+    "octocat",
+    "JasonEtco",
+  ],
+  "body": "Goodbye!",
+  "labels": Array [],
+  "milestone": 1,
+  "title": "Hello!",
+}
+`;
+
 exports[`create-an-issue logs a helpful error if creating an issue throws an error 1`] = `
 Array [
   Array [

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`create-an-issue checks the value of update_existing 1`] = `
+Object {
+  "assignees": Array [
+    "octocat",
+    "JasonEtco",
+  ],
+  "body": "Goodbye!",
+  "labels": Array [],
+  "milestone": 1,
+  "title": "Hello!",
+}
+`;
+
 exports[`create-an-issue creates a new issue 1`] = `
 Object {
   "assignees": Array [],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -155,21 +155,40 @@ describe('create-an-issue', () => {
     nock.cleanAll()
     nock('https://api.github.com')
       .get(/\/search\/issues.*/).reply(200, {
-        items: [{ number: 1, title: 'Hello!' }]
+        items: [{ number: 1, title: 'Hello!', html_url: '/issues/1' }]
       })
-      .patch(/\/repos\/.*\/.*\/issues\/.*/).reply(200, {})
+      .patch(/\/repos\/.*\/.*\/issues/).reply(200, (_, body: any) => {
+        return {
+          title: body.title,
+          number: 1,
+          html_url: '/issues/1'
+        }
+      })
     process.env.INPUT_UPDATE_EXISTING = 'true'
 
     await createAnIssue(tools)
     expect(params).toMatchSnapshot()
-    expect(tools.exit.success).toHaveBeenCalled()
+    expect(tools.exit.success).toHaveBeenCalledWith('Updated issue Hello!#1: /issues/1')
+  })
+
+  it('finds, but does not update an existing issue with the same title', async () => {
+    nock.cleanAll()
+    nock('https://api.github.com')
+      .get(/\/search\/issues.*/).reply(200, {
+        items: [{ number: 1, title: 'Hello!', html_url: '/issues/1' }]
+      })
+    process.env.INPUT_UPDATE_EXISTING = 'false'
+
+    await createAnIssue(tools)
+    expect(params).toMatchSnapshot()
+    expect(tools.exit.success).toHaveBeenCalledWith('Existing issue Hello!#1: /issues/1 found but not updated')
   })
 
   it('exits when updating an issue fails', async () => {
     nock.cleanAll()
     nock('https://api.github.com')
       .get(/\/search\/issues.*/).reply(200, {
-        items: [{ number: 1, title: 'Hello!' }]
+        items: [{ number: 1, title: 'Hello!', html_url: '/issues/1' }]
       })
       .patch(/\/repos\/.*\/.*\/issues\/.*/).reply(500, {
         message: 'Updating issue failed'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -151,6 +151,14 @@ describe('create-an-issue', () => {
     expect(tools.log.success).toHaveBeenCalled()
   })
 
+  it('checks the value of update_existing', async () => {
+    process.env.INPUT_UPDATE_EXISTING = 'invalid'
+
+    await createAnIssue(tools)
+    expect(params).toMatchSnapshot()
+    expect(tools.exit.failure).toHaveBeenCalledWith('Invalid value update_existing=invalid, must be one of true or false')
+  })
+
   it('updates an existing issue with the same title', async () => {
     nock.cleanAll()
     nock('https://api.github.com')


### PR DESCRIPTION
As far as I can see `update_existing=garbage` or `update_existing=false` works as `update_existing=true` today because `Boolean` doesn't parse but casts anything to true/false. With this change `update_existing` can be `true`, `false` and undefined.

- When `true`, an existing issue is updated.
- When `false`, an existing issue is not updated.
- When `undefined`, a new issue is always created.

Closes #108.
 