### PR TITLE
Support repo.repo and repo.owner as template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ labels: bug, enhancement
 Someone just pushed, oh no! Here's who did it: {{ payload.sender.login }}.
 ```
 
-You'll notice that the above example has some `{{ mustache }}` variables. Your issue templates have access to everything about the event that triggered the action. [Here is a list of all of the available template variables](https://github.com/JasonEtco/actions-toolkit#toolscontext). You can also use environment variables:
+You'll notice that the above example has some `{{ mustache }}` variables. Your issue templates have access to several things about the event that triggered the action. Besides `issue` and `pullRequest`, you have access to all the template variables [on this list](https://github.com/JasonEtco/actions-toolkit#toolscontext). You can also use environment variables:
 
 ```yaml
 - uses: JasonEtco/create-an-issue@v2

--- a/src/action.ts
+++ b/src/action.ts
@@ -15,6 +15,7 @@ export async function createAnIssue (tools: Toolkit) {
 
   const templateVariables = {
     ...tools.context,
+    repo: tools.context.repo,
     env: process.env,
     date: Date.now()
   }

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -164,6 +164,26 @@ Array [
 ]
 `;
 
+exports[`create-an-issue creates a new issue with the context.repo template variables 1`] = `
+Object {
+  "assignees": Array [],
+  "body": "Are you looking for results on our gh-pages branch?
+
+Just click this link! https://JasonEtco.github.io/waddup/path/to/my/pageindex.html
+",
+  "labels": Array [],
+  "title": "This Issue has a generalizable GitHub Pages Link",
+}
+`;
+
+exports[`create-an-issue creates a new issue with the context.repo template variables 2`] = `
+Array [
+  Array [
+    "Created issue This Issue has a generalizable GitHub Pages Link#1: www",
+  ],
+]
+`;
+
 exports[`create-an-issue logs a helpful error if creating an issue throws an error 1`] = `
 Array [
   Array [

--- a/tests/fixtures/.github/context-repo-template.md
+++ b/tests/fixtures/.github/context-repo-template.md
@@ -1,0 +1,6 @@
+---
+title: This Issue has a generalizable GitHub Pages Link
+---
+Are you looking for results on our gh-pages branch?
+
+Just click this link! https://{{ repo.owner }}.github.io/{{ repo.repo }}/path/to/my/pageindex.html

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -80,6 +80,14 @@ describe('create-an-issue', () => {
     expect((tools.log.success as any).mock.calls).toMatchSnapshot()
   })
 
+  it('creates a new issue with the context.repo template variables', async () => {
+    process.env.INPUT_FILENAME = '.github/context-repo-template.md'
+    await createAnIssue(tools)
+    expect(params).toMatchSnapshot()
+    expect(tools.log.success).toHaveBeenCalled()
+    expect((tools.log.success as any).mock.calls).toMatchSnapshot()
+  })
+
   it('creates a new issue with assignees, labels and a milestone', async () => {
     process.env.INPUT_FILENAME = '.github/kitchen-sink.md'
     await createAnIssue(tools)


### PR DESCRIPTION
# Description

Adding the `repo: tools.context.repo,` to the `templateVariables` allows us to use `{{ repo.owner }}` and `{{ repo.repo }}` in the issue template mark down.

One example useful test-case with this is for constructing links to the `gh-pages` static web pages without having to hardcode these parameters or manipulate the `GITHUB_REPOSITORY` variable:

e.g. `https://{{ repo.owner }}.github.io/{{ repo.repo }}/path/to/my/pageindex.html`

Fixes #106 