### PR TITLE
Fix search_existing =all

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -61,7 +61,7 @@ export async function createAnIssue (tools: Toolkit) {
   tools.log.debug('Templates compiled', templated)
 
   if (updateExisting !== null) {
-    tools.log.info(`Fetching issues with title "${templated.title}"`)
+    tools.log.info(`Fetching ${searchExistingType} issues with title "${templated.title}"`)
     const existingIssues = await tools.github.search.issuesAndPullRequests({
       q: `is:${searchExistingType} is:issue repo:${process.env.GITHUB_REPOSITORY} in:title ${templated.title}`
     })

--- a/src/action.ts
+++ b/src/action.ts
@@ -24,14 +24,8 @@ export async function createAnIssue (tools: Toolkit) {
   const template = tools.inputs.filename || '.github/ISSUE_TEMPLATE.md'
   const assignees = tools.inputs.assignees
 
-  let searchExistingType: String | null = 'is:open '
-  if (tools.inputs.search_existing === 'open') {
-    searchExistingType = 'is:open '
-  } else if (tools.inputs.search_existing === 'closed') {
-    searchExistingType = 'is:closed '
-  } else if (tools.inputs.search_existing === 'all') {
-    searchExistingType = ''
-  } else {
+  const searchExistingType: string = tools.inputs.search_existing || 'open'
+  if (!['open', 'closed', 'all'].includes(searchExistingType)) {
     tools.exit.failure(`Invalid value search_existing=${tools.inputs.search_existing}, must be one of open, closed or all`)
   }
 
@@ -72,8 +66,9 @@ export async function createAnIssue (tools: Toolkit) {
 
   if (updateExisting !== null) {
     tools.log.info(`Fetching ${searchExistingType}issues with title "${templated.title}"`)
+    const searchExistingQuery = (searchExistingType === 'all') ? '' : `is:${searchExistingType} `
     const existingIssues = await tools.github.search.issuesAndPullRequests({
-      q: `${searchExistingType}is:issue repo:${process.env.GITHUB_REPOSITORY} in:title ${templated.title}`
+      q: `${searchExistingQuery}is:issue repo:${process.env.GITHUB_REPOSITORY} in:title ${templated.title}`
     })
     const existingIssue = existingIssues.data.items.find(issue => issue.title === templated.title)
     if (existingIssue) {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`create-an-issue checks the value of search_existing 1`] = `
+Object {
+  "assignees": Array [
+    "octocat",
+    "JasonEtco",
+  ],
+  "body": "Goodbye!",
+  "labels": Array [],
+  "milestone": 1,
+  "title": "Hello!",
+}
+`;
+
 exports[`create-an-issue checks the value of update_existing 1`] = `
 Object {
   "assignees": Array [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -193,7 +193,11 @@ describe('create-an-issue', () => {
         const q = parsedQuery['q']
         if (typeof(q) === 'string') {
           const args = q.split(' ')
-          return args.includes('is:all') && args.includes('is:issue')
+          if (args.includes('is:open') || args.includes('is:closed')) {
+            return false
+          } else {
+            return args.includes('is:issue')
+          }
         } else {
           return false
         }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -185,6 +185,14 @@ describe('create-an-issue', () => {
     expect(tools.exit.failure).toHaveBeenCalledWith('Invalid value update_existing=invalid, must be one of true or false')
   })
 
+  it('checks the value of search_existing', async () => {
+    process.env.INPUT_SEARCH_EXISTING = 'invalid'
+
+    await createAnIssue(tools)
+    expect(params).toMatchSnapshot()
+    expect(tools.exit.failure).toHaveBeenCalledWith('Invalid value search_existing=invalid, must be one of open, closed or all')
+  })
+
   it('updates an existing closed issue with the same title', async () => {
     nock.cleanAll()
     nock('https://api.github.com')


### PR DESCRIPTION
I did a poor job with search_existing=all by not testing it with actual issues and relying on the UI for testing queries. The latter would ignore `is:all` and default to returning all issues, but that's not the case with the API.

I have two issues with title=tt, one open, one closed.

```
curl -s -H 'Accept: application/vnd.github.v3.text-match+json' 'https://api.github.com/search/issues?q=is:all+is:issue+repo:dblock/opensearch-build+in:title+tt' | jq ".items[].url"
# returns nothing
```

```
$ curl -s -H 'Accept: application/vnd.github.v3.text-match+json' 'https://api.github.com/search/issues?q=is:open+is:issue+repo:dblock/opensearch-build+in:title+tt' | jq ".items[].url"
"https://api.github.com/repos/dblock/opensearch-build/issues/26"

$ curl -s -H 'Accept: application/vnd.github.v3.text-match+json' 'https://api.github.com/search/issues?q=is:closed+is:issue+repo:dblock/opensearch-build+in:title+tt' | jq ".items[].url"
"https://api.github.com/repos/dblock/opensearch-build/issues/27"

$ curl -s -H 'Accept: application/vnd.github.v3.text-match+json' 'https://api.github.com/search/issues?q=is:issue+repo:dblock/opensearch-build+in:title+tt' | jq ".items[].url"
"https://api.github.com/repos/dblock/opensearch-build/issues/26"
"https://api.github.com/repos/dblock/opensearch-build/issues/27"
```
