### PR TITLE
Set outputs when an issue is updated or found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ steps:
 
 ### Outputs
 
-If you need the number or URL of the issue that was created for another Action, you can use the `number` or `url` outputs, respectively. For example:
+If you need the number or URL of the issue that was created or updated for another Action, you can use the `number`, `url` and `status` outputs, respectively. For example:
 
 ```yaml
 steps:
@@ -104,6 +104,10 @@ steps:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     id: create-issue
-  - run: 'echo Created issue number ${{ steps.create-issue.outputs.number }}'
-  - run: 'echo Created ${{ steps.create-issue.outputs.url }}'
+  - run: 'echo number: ${{ steps.create-issue.outputs.number }}'
+  - run: 'echo status: ${{ steps.create-issue.outputs.status }}'
+  - run: 'echo url: ${{ steps.create-issue.outputs.url }}'
 ```
+
+* The `number` and `url` outputs speak for themselves.
+* The `status` is one of `created`, `updated` or `found`.

--- a/src/action.ts
+++ b/src/action.ts
@@ -68,6 +68,7 @@ export async function createAnIssue (tools: Toolkit) {
     const existingIssue = existingIssues.data.items.find(issue => issue.title === templated.title)
     if (existingIssue) {
       if (updateExisting === false) {
+        setOutputs(tools, existingIssue, 'found')
         tools.exit.success(`Existing issue ${existingIssue.title}#${existingIssue.number}: ${existingIssue.html_url} found but not updated`)
       } else {
         try {
@@ -77,7 +78,7 @@ export async function createAnIssue (tools: Toolkit) {
             issue_number: existingIssue.number,
             body: templated.body
           })
-          setOutputs(tools, issue)
+          setOutputs(tools, existingIssue, 'updated')
           tools.exit.success(`Updated issue ${existingIssue.title}#${existingIssue.number}: ${existingIssue.html_url}`)
         } catch (err: any) {
           return logError(tools, template, 'updating', err)
@@ -99,7 +100,7 @@ export async function createAnIssue (tools: Toolkit) {
       milestone: Number(tools.inputs.milestone || attributes.milestone) || undefined
     })
 
-    setOutputs(tools, issue)
+    setOutputs(tools, issue.data, 'created')
     tools.log.success(`Created issue ${issue.data.title}#${issue.data.number}: ${issue.data.html_url}`)
   } catch (err: any) {
     return logError(tools, template, 'creating', err)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,4 @@
 import { Toolkit } from 'actions-toolkit'
-import { IssuesCreateResponseData } from '@octokit/types'
 
 export interface FrontMatterAttributes {
   title: string
@@ -8,9 +7,10 @@ export interface FrontMatterAttributes {
   milestone?: string | number
 }
 
-export function setOutputs (tools: Toolkit, issue: { data: IssuesCreateResponseData }) {
-  tools.outputs.number = String(issue.data.number)
-  tools.outputs.url = issue.data.html_url
+export function setOutputs (tools: Toolkit, issue: { number: number, html_url: string }, status: string) {
+  tools.outputs.number = String(issue.number)
+  tools.outputs.url = issue.html_url
+  tools.outputs.status = status
 }
 
 export function listToArray (list?: string[] | string) {


### PR DESCRIPTION
This sets output also when the issue is found or updated.

Open to better naming conventions for the new fields (`status` may not be ideal).

This does change behavior whereas there was no output in the past. Worth a major version bump?

Closes #85. 