### PR TITLE
Don't include `is:all` in issue filter

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -193,7 +193,7 @@ describe('create-an-issue', () => {
         const q = parsedQuery['q']
         if (typeof(q) === 'string') {
           const args = q.split(' ')
-          return args.includes('is:all') && args.includes('is:issue')
+          return !args.includes('is:all') && args.includes('is:issue')
         } else {
           return false
         }


### PR DESCRIPTION
This PR adds a check for valid search states before attempting to append `is:<state>` to the search query. This should prevent any invalid states (like `all`) from causing it to return no search results.

Closes https://github.com/JasonEtco/create-an-issue/issues/121