### PR TITLE
Add more fields to schema

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,8 @@ export const frontmatterSchema = z
     assignees: z.union([z.array(z.string()), z.string()]).optional(),
     labels: z.union([z.array(z.string()), z.string()]).optional(),
     milestone: z.union([z.string(), z.number()]).optional(),
+    name: z.string().optional(),
+    about: z.string().optional(),
   })
   .strict();
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -240,7 +240,7 @@ exports[`create-an-issue logs a helpful error if the frontmatter is invalid 1`] 
   [
     {
       "_errors": [
-        "Unrecognized key(s) in object: 'name', 'not_a_thing'",
+        "Unrecognized key(s) in object: 'not_a_thing'",
       ],
       "labels": {
         "_errors": [


### PR DESCRIPTION
Closes #145 for an unintended regression that is causing a mismatch with the fields that `create-an-issue` is expecting, and fields that GitHub's issue templates support.