### PR TITLE
Add node id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ steps:
 
 ### Outputs
 
-If you need the number or URL of the issue that was created for another Action, you can use the `number` or `url` outputs, respectively. For example:
+If you need the number or URL of the issue that was created for another Action, you can use the `number` or `url` outputs, respectively. The `node id` is useful if another action uses the [GraphQL API](https://docs.github.com/en/graphql/reference). For example:
 
 ```yaml
 steps:

--- a/action.yml
+++ b/action.yml
@@ -29,3 +29,5 @@ outputs:
     description: Number of the issue that was created
   url:
     description: URL of the issue that was created
+  id:
+    description: node-id of the issue that was created

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,10 +16,11 @@ export type FrontMatterAttributes = z.infer<typeof frontmatterSchema>;
 
 export function setOutputs(
   tools: Toolkit,
-  issue: { number: number; html_url: string }
+  issue: { number: number; html_url: string; node_id: string }
 ) {
   tools.outputs.number = String(issue.number);
   tools.outputs.url = issue.html_url;
+  tools.outputs.id = issue.node_id;
 }
 
 export function listToArray(list?: string[] | string) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,6 +38,7 @@ describe("create-an-issue", () => {
           title: body.title,
           number: 1,
           html_url: "www",
+          node_id: "node",
         };
       });
 
@@ -57,9 +58,10 @@ describe("create-an-issue", () => {
     expect((tools.log.success as any).mock.calls).toMatchSnapshot();
 
     // Verify that the outputs were set
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(3);
     expect(core.setOutput).toHaveBeenCalledWith("url", "www");
     expect(core.setOutput).toHaveBeenCalledWith("number", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("id", "node");
   });
 
   it("creates a new issue from a different template", async () => {
@@ -143,6 +145,7 @@ describe("create-an-issue", () => {
           title: body.title,
           number: 1,
           html_url: "www",
+          node_id: "node",
         };
       });
 


### PR DESCRIPTION
## Add node id to outputs
For example, it is used when [linking a project](https://docs.github.com/en/graphql/reference/input-objects#addprojectv2itembyidinput) to a created issue.
I referred to [here](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue) for `node-id`.