### PR TITLE
Use node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm ci
       - run: npm test
       - name: codecov

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Create an issue
 description: Creates a new issue using a template with front matter.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: alert-circle

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "zod": "^3.20.2"
       },
       "devDependencies": {
-        "@tsconfig/node-lts": "^20.1.1",
+        "@tsconfig/recommended": "^1.0.3",
         "@types/jest": "^29.1.2",
         "@types/nunjucks": "^3.2.1",
         "@vercel/ncc": "^0.34.0",
@@ -1534,10 +1534,10 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@tsconfig/node-lts": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-20.1.1.tgz",
-      "integrity": "sha512-V7wHydi1dv8I8xiOX3pJ0lhC+MlOakznvLks94J6y/TqQK6DBcbdD1G4jEq8yU+s6lBASPn4e1Ci636fDqeyvQ==",
+    "node_modules/@tsconfig/recommended": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
+      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "zod": "^3.20.2"
       },
       "devDependencies": {
-        "@tsconfig/node12": "^1.0.11",
+        "@tsconfig/node-lts": "^20.1.1",
         "@types/jest": "^29.1.2",
         "@types/nunjucks": "^3.2.1",
         "@vercel/ncc": "^0.34.0",
@@ -1534,10 +1534,10 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+    "node_modules/@tsconfig/node-lts": {
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-20.1.1.tgz",
+      "integrity": "sha512-V7wHydi1dv8I8xiOX3pJ0lhC+MlOakznvLks94J6y/TqQK6DBcbdD1G4jEq8yU+s6lBASPn4e1Ci636fDqeyvQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.11",
+    "@tsconfig/node-lts": "^20.1.1",
     "@types/jest": "^29.1.2",
     "@types/nunjucks": "^3.2.1",
     "@vercel/ncc": "^0.34.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "zod": "^3.20.2"
   },
   "devDependencies": {
-    "@tsconfig/node-lts": "^20.1.1",
+    "@tsconfig/recommended": "^1.0.3",
     "@types/jest": "^29.1.2",
     "@types/nunjucks": "^3.2.1",
     "@vercel/ncc": "^0.34.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node-lts/tsconfig.json",
+  "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": true
   }


### PR DESCRIPTION
This pull request primarily focuses on upgrading the Node.js version used across different parts of the codebase to version 20. The changes affect the continuous integration pipeline, the action configuration, and the development dependencies.

Node.js version upgrade:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L4-R4): The Node.js version used in the action configuration has been updated from node16 to node20. This change will affect the environment in which the GitHub action runs.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL15-R18): The Node.js version used in the continuous integration pipeline has been updated from 18.x to 20.x. This change will affect the environment in which the CI jobs are run.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R22): The Node.js version specified in the development dependencies has been updated from `@tsconfig/node12` to `@tsconfig/node20`. This change will affect the environment in which the development and testing tasks are run.

This will resolve #175 and the following warning that is currently produced when this action is used in a workflow:

> [!WARNING]
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.